### PR TITLE
Try vector

### DIFF
--- a/example/MainM.hs
+++ b/example/MainM.hs
@@ -26,7 +26,7 @@ main = do
     let n = length inputData
     putStrLn $ "total input: " ++ show n
 
-    let n' = if (argc < 2) then n else (read (args !! 1)) 
+    let n' = if (argc < 2) then n else (read (args !! 1))
     putStrLn $ "using: " ++ show n' ++ " points from input"
 
     let iters = if (argc < 3) then 1000 else (read (args !! 2))
@@ -34,7 +34,7 @@ main = do
 
     inputMatrix <- MA.fromListsM MA.Seq $ take n' inputData
 --    forTsne3D_M outputResult def Nothing inputMatrix
-    
+
     runEffect $ for ((tsne3D_M def Nothing $ inputMatrix) >-> Pipes.take iters) $ \r -> do
         lift $ outputResult r
 
@@ -43,8 +43,7 @@ readDataFile f = do
     d <- readFile f
     return $ map read (lines d)
 
-outputResult :: TSNEOutput3D -> IO ()
+outputResult :: TSNEOutput3D_M -> IO ()
 outputResult s = do
-    putStrLn $ "iteration: " ++ (show.tsneIteration3D) s
-    putStrLn $ "cost: " ++ (show.tsneCost3D) s
-
+    putStrLn $ "iteration: " ++ (show.tsneIteration3D_M) s
+    putStrLn $ "cost: " ++ (show.tsneCost3D_M) s

--- a/src/Data/Algorithm/TSNE.hs
+++ b/src/Data/Algorithm/TSNE.hs
@@ -1,8 +1,9 @@
-module Data.Algorithm.TSNE ( 
+module Data.Algorithm.TSNE (
         TSNEOptions(..),
         tsne3D,
         forTsne3D,
         TSNEOutput3D(..),
+        TSNEOutput3D_M(..),
         tsne2D,
         forTsne2D,
         TSNEOutput2D(..),
@@ -34,7 +35,7 @@ tsne3D opts input = do
 forTsne3D :: (TSNEOutput3D -> IO ()) -> TSNEOptions -> TSNEInput -> IO ()
 forTsne3D action opts input = do
     runEffect $ for (tsne3D opts input) $ \o -> do
-        lift $ action o    
+        lift $ action o
 
 -- | Generates an infinite stream of 2D tSNE iterations.
 tsne2D :: TSNEOptions -> TSNEInput -> Producer TSNEOutput2D IO ()
@@ -47,28 +48,28 @@ tsne2D opts input = do
 forTsne2D :: (TSNEOutput2D -> IO ()) -> TSNEOptions -> TSNEInput -> IO ()
 forTsne2D action opts input = do
     runEffect $ for (tsne2D opts input) $ \o -> do
-        lift $ action o    
+        lift $ action o
 
 -- massiv versions
 
 -- | Generates an infinite stream of 3D tSNE iterations.
-tsne3D_M :: TSNEOptions -> Maybe Int -> TSNEInputM -> Producer TSNEOutput3D IO ()
+tsne3D_M :: TSNEOptions -> Maybe Int -> TSNEInputM -> Producer TSNEOutput3D_M IO ()
 tsne3D_M opts seedM input = do
-  let MA.Sz2 inputLength _ = MA.size input 
+  let MA.Sz2 inputLength _ = MA.size input
   st <- liftIO $ initState3D_M seedM inputLength
   runTSNE3D_M opts input ps st
     where ps = neighbourProbabilitiesM opts input
 
 -- | Executes an IO action for each iteration of the 3D tSNE algorithm.
-forTsne3D_M :: (TSNEOutput3D -> IO ()) -> TSNEOptions -> Maybe Int -> TSNEInputM -> IO ()
+forTsne3D_M :: (TSNEOutput3D_M -> IO ()) -> TSNEOptions -> Maybe Int -> TSNEInputM -> IO ()
 forTsne3D_M action opts seedM input = do
     runEffect $ for (tsne3D_M opts seedM input) $ \o -> do
-        lift $ action o    
+        lift $ action o
 
 -- | Generates an infinite stream of 2D tSNE iterations.
 tsne2D_M :: TSNEOptions -> Maybe Int -> TSNEInputM -> Producer TSNEOutput2D IO ()
 tsne2D_M opts seedM input = do
-  let MA.Sz2 inputLength _ = MA.size input 
+  let MA.Sz2 inputLength _ = MA.size input
   st <- liftIO $ initState2D_M seedM inputLength
   runTSNE2D_M opts input ps st
     where ps = neighbourProbabilitiesM opts input
@@ -77,4 +78,4 @@ tsne2D_M opts seedM input = do
 forTsne2D_M :: (TSNEOutput2D -> IO ()) -> TSNEOptions -> Maybe Int -> TSNEInputM -> IO ()
 forTsne2D_M action opts seedM input = do
     runEffect $ for (tsne2D_M opts seedM input) $ \o -> do
-        lift $ action o    
+        lift $ action o

--- a/src/Data/Algorithm/TSNE/Run2D.hs
+++ b/src/Data/Algorithm/TSNE/Run2D.hs
@@ -70,10 +70,12 @@ runTSNE2D_M :: TSNEOptions
             -> MA.Matrix MA.U Probability
             -> TSNEStateM
             -> Producer TSNEOutput2D IO ()
-runTSNE2D_M opts vs ps st = do
-    yield $ output2D_M ps st
-    st' <- force <$> stepTSNE_M opts vs ps st
-    runTSNE2D_M opts vs ps st'
+runTSNE2D_M opts vs ps = go
+    where
+        go st = do
+            yield $ output2D_M ps st
+            st' <- force <$> stepTSNE_M opts vs ps st
+            go st'
 {-# INLINEABLE runTSNE2D_M #-}
 
 solution2D_M :: MA.Matrix MA.U Double -> [Position2D]

--- a/src/Data/Algorithm/TSNE/Run3D.hs
+++ b/src/Data/Algorithm/TSNE/Run3D.hs
@@ -71,10 +71,12 @@ runTSNE3D_M :: TSNEOptions
             -> MA.Matrix MA.U Probability
             -> TSNEStateM
             -> Producer TSNEOutput3D_M IO ()
-runTSNE3D_M opts vs ps st = do
-    yield $ output3D_M ps st
-    st' <- force <$> stepTSNE_M opts vs ps st
-    runTSNE3D_M opts vs ps st'
+runTSNE3D_M opts vs ps = go
+    where
+        go st = do
+            yield $ output3D_M ps st
+            st' <- force <$> stepTSNE_M opts vs ps st
+            go st'
 {-# INLINEABLE runTSNE3D_M #-}
 
 solution3D_M :: MA.Matrix MA.U Double -> MA.Vector MA.U Position3D

--- a/src/Data/Algorithm/TSNE/Run3D.hs
+++ b/src/Data/Algorithm/TSNE/Run3D.hs
@@ -70,19 +70,19 @@ runTSNE3D_M :: TSNEOptions
             -> TSNEInputM
             -> MA.Matrix MA.U Probability
             -> TSNEStateM
-            -> Producer TSNEOutput3D IO ()
+            -> Producer TSNEOutput3D_M IO ()
 runTSNE3D_M opts vs ps st = do
     yield $ output3D_M ps st
     st' <- force <$> stepTSNE_M opts vs ps st
     runTSNE3D_M opts vs ps st'
 {-# INLINEABLE runTSNE3D_M #-}
 
-solution3D_M :: MA.Matrix MA.U Double -> [Position3D]
-solution3D_M = solution3D . MA.toLists2
+solution3D_M :: MA.Matrix MA.U Double -> MA.Vector MA.U Position3D
+solution3D_M ma = MA.computeAs MA.U $ MA.zip3 (ma MA.!> 0) (ma MA.!> 1) (ma MA.!> 3)
 {-# INLINEABLE solution3D_M #-}
 
-output3D_M :: MA.Matrix MA.U Double -> TSNEStateM -> TSNEOutput3D
-output3D_M pss st = TSNEOutput3D i s c
+output3D_M :: MA.Matrix MA.U Double -> TSNEStateM -> TSNEOutput3D_M
+output3D_M pss st = TSNEOutput3D_M i s c
     where
         i = stIterationM st
         s = (solution3D_M . stSolutionM) st

--- a/src/Data/Algorithm/TSNE/Run3D.hs
+++ b/src/Data/Algorithm/TSNE/Run3D.hs
@@ -29,7 +29,7 @@ initSolution3D n = do
 
 runTSNE3D :: TSNEOptions -> TSNEInput -> [[Probability]] -> TSNEState -> Producer TSNEOutput3D IO ()
 runTSNE3D opts vs ps st = do
-    yield $ output3D ps st
+    yield $ output3D ps st -- producing output isn't benchmarked (unevaluated)
     let st' = force $ stepTSNE opts vs ps st
     runTSNE3D opts vs ps st'
 
@@ -74,13 +74,13 @@ runTSNE3D_M :: TSNEOptions
 runTSNE3D_M opts vs ps = go
     where
         go st = do
-            yield $ output3D_M ps st
+            yield $ output3D_M ps st -- producing output isn't benchmarked (unevaluated)
             st' <- force <$> stepTSNE_M opts vs ps st
             go st'
 {-# INLINEABLE runTSNE3D_M #-}
 
 solution3D_M :: MA.Matrix MA.U Double -> MA.Vector MA.U Position3D
-solution3D_M ma = MA.computeAs MA.U $ MA.zip3 (ma MA.!> 0) (ma MA.!> 1) (ma MA.!> 3)
+solution3D_M ma = MA.computeAs MA.U $ MA.zip3 (ma MA.!> 0) (ma MA.!> 1) (ma MA.!> 2)
 {-# INLINEABLE solution3D_M #-}
 
 output3D_M :: MA.Matrix MA.U Double -> TSNEStateM -> TSNEOutput3D_M

--- a/src/Data/Algorithm/TSNE/Stepping.hs
+++ b/src/Data/Algorithm/TSNE/Stepping.hs
@@ -92,19 +92,20 @@ stepTSNE_M opts vs ps st =  do
 --  MA.liftIO $ putStrLn $ "size of s' = recentered s+d'=" ++ show (MA.size s')    
   return $ TSNEStateM i' s' g' d'
 
-gradientsM :: MA.MonadThrow m => MA.Matrix MA.U Probability -> TSNEStateM -> m (MA.Matrix MA.U Gradient)
-gradientsM pss st = fromOuterSlices $ MA.map gradient ssV
+gradientsM :: MA.MonadThrow m =>
+  MA.Matrix MA.U Probability -> TSNEStateM -> m (MA.Matrix MA.U Gradient)
+gradientsM pss st = pure $! asMatrixM $ MA.map gradient ssV
     where
         ss = stSolutionM st
         ssV :: MA.Vector MA.D (MA.Vector MA.M Double) = asVectorsM ss
         pssV  = asVectorsM pss
---        gradient :: MA.Vector MA.U Double -> MA.Vector MA.U Gradient
-        gradient s = zipWith4M (f s) s pssV qssV qssV'
         MA.Sz2 _ cols = MA.size ss
         i = stIterationM st -- Int
         qd = qdistM ss
-        qssV  :: MA.Vector MA.D (MA.Vector MA.M Double) = asVectorsM $ qd -- MA.Matrix MA.D Double 
-        qssV' :: MA.Vector MA.D (MA.Vector MA.M Double) = asVectorsM $ MA.computeAs MA.U $ qdistM'' qd -- MA.Matrix MA.D Double
+        qssV  :: MA.Vector MA.D (MA.Vector MA.M Double) = asVectorsM qd
+        qssV' :: MA.Vector MA.D (MA.Vector MA.M Double) = asVectorsM $ MA.computeAs MA.U $ qdistM'' qd
+        gradient :: MA.Vector MA.M Double -> MA.Vector MA.D Gradient
+        gradient s = zipWith4M (f s) s pssV qssV qssV'
         f :: MA.Vector MA.M Double -> Double -> MA.Vector MA.M Double -> MA.Vector MA.M Double -> MA.Vector MA.M Double -> Double
         f s x ps qs qs' = MA.sum $ zipWith4M g s ps qs qs'
             where

--- a/src/Data/Algorithm/TSNE/Stepping.hs
+++ b/src/Data/Algorithm/TSNE/Stepping.hs
@@ -95,7 +95,7 @@ stepTSNE_M opts vs ps st =  do
 
 gradientsM :: MA.MonadThrow m =>
   MA.Matrix MA.U Probability -> TSNEStateM -> m (MA.Matrix MA.U Gradient)
-gradientsM pss st = pure $! asMatrixM $ MA.map gradient ssV
+gradientsM pss st = MA.compute <$> MA.stackOuterSlicesM (MA.map gradient ssV)
     where
         ss = stSolutionM st
         ssV :: MA.Vector MA.D (MA.Vector MA.M Double) = MA.outerSlices ss

--- a/src/Data/Algorithm/TSNE/Stepping.hs
+++ b/src/Data/Algorithm/TSNE/Stepping.hs
@@ -36,9 +36,9 @@ stepTSNE opts vs ps st = TSNEState i' s'' g' d'
 newGain :: Gain -> Delta -> Gradient -> Gain
 newGain g d gr = max 0.01 g'
     where
-        g' = if signum d == signum gr 
+        g' = if signum d == signum gr
                 then g * 0.8
-                else g + 0.2  
+                else g + 0.2
 
 newDelta :: Double -> Int -> Gain -> Delta -> Gradient -> Delta
 newDelta e i g' d gr = (m * d) - (e * g' * gr)
@@ -53,7 +53,7 @@ gradients pss st = gradient <$> ss
         ss = stSolution st
         i = stIteration st
         qss = qdist ss
-        qss' = qdist' ss 
+        qss' = qdist' ss
         f :: [Double] -> Double -> [Double] -> [Double] -> [Double] -> Gradient
         f s x ps qs qs' = sum $ zipWith4 g s ps qs qs'
             where
@@ -65,11 +65,12 @@ gradients pss st = gradient <$> ss
 cost :: [[Double]] -> TSNEState -> Double
 cost pss st = sumsum $ (zipWith.zipWith) c pss (qdist' (stSolution st))
     where
-        c p q = -p * log q 
+        c p q = -p * log q
 
 -- massiv versions
 
-stepTSNE_M :: MA.MonadThrow m => TSNEOptions -> TSNEInputM -> MA.Matrix MA.U Probability -> TSNEStateM -> m TSNEStateM
+stepTSNE_M :: MA.MonadThrow m =>
+  TSNEOptions -> TSNEInputM -> MA.Matrix MA.U Probability -> TSNEStateM -> m TSNEStateM
 stepTSNE_M opts vs ps st =  do
   let i = stIterationM st
       s = stSolutionM st
@@ -82,14 +83,14 @@ stepTSNE_M opts vs ps st =  do
   MA.liftIO $ putStrLn $ "size of delta=" ++ show (MA.size d)
 -}
   gr <- gradientsM ps st
---  MA.liftIO $ putStrLn $ "size of gradient=" ++ show (MA.size gr)    
+--  MA.liftIO $ putStrLn $ "size of gradient=" ++ show (MA.size gr)
   let i' = i + 1
       g' = MA.computeAs MA.U $ MA.zipWith3 newGain g d gr
       d' = MA.computeAs MA.U $ MA.zipWith3 (newDelta (tsneLearningRate opts) i) g' d gr
 --  MA.liftIO $ putStrLn $ "size of g'=" ++ show (MA.size g')
---  MA.liftIO $ putStrLn $ "size of d'=" ++ show (MA.size d')    
+--  MA.liftIO $ putStrLn $ "size of d'=" ++ show (MA.size d')
       s' = MA.computeAs MA.U $ recenterM $ MA.zipWith (+) s d'
---  MA.liftIO $ putStrLn $ "size of s' = recentered s+d'=" ++ show (MA.size s')    
+--  MA.liftIO $ putStrLn $ "size of s' = recentered s+d'=" ++ show (MA.size s')
   return $ TSNEStateM i' s' g' d'
 
 gradientsM :: MA.MonadThrow m =>
@@ -97,17 +98,17 @@ gradientsM :: MA.MonadThrow m =>
 gradientsM pss st = pure $! asMatrixM $ MA.map gradient ssV
     where
         ss = stSolutionM st
-        ssV :: MA.Vector MA.D (MA.Vector MA.M Double) = asVectorsM ss
-        pssV  = asVectorsM pss
+        ssV :: MA.Vector MA.D (MA.Vector MA.M Double) = MA.outerSlices ss
+        pssV  = MA.outerSlices pss
         MA.Sz2 _ cols = MA.size ss
         i = stIterationM st -- Int
         qd = qdistM ss
-        qssV  :: MA.Vector MA.D (MA.Vector MA.M Double) = asVectorsM qd
-        qssV' :: MA.Vector MA.D (MA.Vector MA.M Double) = asVectorsM $ MA.computeAs MA.U $ qdistM'' qd
+        qssV  :: MA.Vector MA.D (MA.Vector MA.M Double) = MA.outerSlices qd
+        qssV' :: MA.Vector MA.D (MA.Vector MA.M Double) = MA.outerSlices $ MA.computeAs MA.U $ qdistM'' qd
         gradient :: MA.Vector MA.M Double -> MA.Vector MA.D Gradient
-        gradient s = zipWith4M (f s) s pssV qssV qssV'
+        gradient s = MA.zipWith4 (f s) s pssV qssV qssV'
         f :: MA.Vector MA.M Double -> Double -> MA.Vector MA.M Double -> MA.Vector MA.M Double -> MA.Vector MA.M Double -> Double
-        f s x ps qs qs' = MA.sum $ zipWith4M g s ps qs qs'
+        f s x ps qs qs' = MA.sum $ MA.zipWith4 g s ps qs qs'
             where
                 g y p q q' = m * (x - y)
                     where

--- a/src/Data/Algorithm/TSNE/Stepping.hs
+++ b/src/Data/Algorithm/TSNE/Stepping.hs
@@ -89,7 +89,7 @@ stepTSNE_M opts vs ps st =  do
       d' = MA.computeAs MA.U $ MA.zipWith3 (newDelta (tsneLearningRate opts) i) g' d gr
 --  MA.liftIO $ putStrLn $ "size of g'=" ++ show (MA.size g')
 --  MA.liftIO $ putStrLn $ "size of d'=" ++ show (MA.size d')
-      s' = MA.computeAs MA.U $ recenterM $ MA.zipWith (+) s d'
+      s' = MA.computeAs MA.U $ recenterM $ MA.computeAs MA.U $ MA.zipWith (+) s d'
 --  MA.liftIO $ putStrLn $ "size of s' = recentered s+d'=" ++ show (MA.size s')
   return $ TSNEStateM i' s' g' d'
 

--- a/src/Data/Algorithm/TSNE/Types.hs
+++ b/src/Data/Algorithm/TSNE/Types.hs
@@ -55,17 +55,17 @@ data TSNEState = TSNEState {
 --type Position2Dm = V.Vector U Double
 --type Position3Dm = V.Vector U Double
 
-type TSNEInputValueM =  MA.Vector MA.U Double 
-type TSNEInputM =  MA.Matrix MA.U Double 
+type TSNEInputValueM =  MA.Vector MA.U Double
+type TSNEInputM =  MA.Matrix MA.U Double
 
-{-
 data TSNEOutput3D_M = TSNEOutput3D_M {
     tsneIteration3D_M :: Int,
-    tsneSolution3_M :: [Position3D], -- Only if this is only for output.  Otherwise we need better.
+    tsneSolution3_M :: MA.Vector MA.U Position3D, -- Only if this is only for output.  Otherwise we need better.
     tsneCost3D_M :: Double
 } deriving (Show, Eq)
 
 
+{-
 data TSNEOutput2D_M = TSNEOutput2D_M {
     tsneIteration2D_M :: Int,
     tsneSolution2D_M :: [Position2D], -- Only if this is only for output.  Otherwise we need better.

--- a/src/Data/Algorithm/TSNE/Types.hs
+++ b/src/Data/Algorithm/TSNE/Types.hs
@@ -74,8 +74,8 @@ data TSNEOutput2D_M = TSNEOutput2D_M {
 -}
 
 data TSNEStateM = TSNEStateM {
-    stIterationM :: Int,
-    stSolutionM :: MA.Matrix MA.U Double, -- dimension (solution) x length (inputs)
-    stGainsM :: MA.Matrix MA.U Gain, -- dimension (solution) x length (inputs)
-    stDeltasM :: MA.Matrix MA.U Delta -- dimension (solution) x length (inputs)
+    stIterationM :: !Int,
+    stSolutionM :: !(MA.Matrix MA.U Double), -- dimension (solution) x length (inputs)
+    stGainsM :: !(MA.Matrix MA.U Gain), -- dimension (solution) x length (inputs)
+    stDeltasM :: !(MA.Matrix MA.U Delta) -- dimension (solution) x length (inputs)
 } deriving (Show, Generic, NFData)

--- a/src/Data/Algorithm/TSNE/Utils.hs
+++ b/src/Data/Algorithm/TSNE/Utils.hs
@@ -76,7 +76,7 @@ distanceSquaredM :: (MA.Source r MA.Ix1 Double
                     )
 
                  => MA.Vector r Double -> MA.Vector r' Double -> Double
-distanceSquaredM as bs = MA.sum $ MA.zipWith (\a b -> let x =  (a - b) in x * x) as bs
+distanceSquaredM as bs = MA.sum $ MA.zipWith (\a b -> let x = a - b in x * x) as bs
 {-# INLINEABLE distanceSquaredM #-}
 
 symmetrizeSqM :: (MA.Numeric r Double
@@ -135,27 +135,27 @@ qdistM'' qd =
   in MA.map f qd
 {-# INLINEABLE qdistM'' #-}
 
-zipWith4M :: (MA.Index ix
-             , MA.Source r1 ix e1
-             , MA.Source r2 ix e2
-             , MA.Source r3 ix e3
-             , MA.Source r4 ix e4
-             )
-          => (e1 -> e2 -> e3 -> e4 -> e)
-         -> MA.Array r1 ix e1
-         -> MA.Array r2 ix e2
-         -> MA.Array r3 ix e3
-         -> MA.Array r4 ix e4
-         -> MA.Array MA.D ix e
-zipWith4M f a1 a2 a3 a4 = MA.zipWith (\(e1, e2) (e3, e4) ->  f e1 e2 e3 e4) (MA.zip a1 a2) (MA.zip a3 a4)
-{-# INLINEABLE zipWith4M #-}
+-- zipWith4M :: (MA.Index ix
+--              , MA.Source r1 ix e1
+--              , MA.Source r2 ix e2
+--              , MA.Source r3 ix e3
+--              , MA.Source r4 ix e4
+--              )
+--           => (e1 -> e2 -> e3 -> e4 -> e)
+--          -> MA.Array r1 ix e1
+--          -> MA.Array r2 ix e2
+--          -> MA.Array r3 ix e3
+--          -> MA.Array r4 ix e4
+--          -> MA.Array MA.D ix e
+-- zipWith4M f a1 a2 a3 a4 = MA.zipWith (\(e1, e2) (e3, e4) ->  f e1 e2 e3 e4) (MA.zip a1 a2) (MA.zip a3 a4)
+-- {-# INLINEABLE zipWith4M #-}
 
-asVectorsM :: MA.OuterSlice r MA.Ix2 e
-           => MA.Matrix r e -> MA.Vector MA.D (MA.Vector (MA.R r) e)
-asVectorsM m =
-  let MA.Sz2 r c = MA.size m
-  in MA.makeArray MA.Seq (MA.Sz1 r) $ \r -> (m MA.!> r)
-{-# INLINEABLE asVectorsM #-}
+-- asVectorsM :: MA.OuterSlice r MA.Ix2 e
+--            => MA.Matrix r e -> MA.Vector MA.D (MA.Vector (MA.R r) e)
+-- asVectorsM m =
+--   let MA.Sz2 r c = MA.size m
+--   in MA.makeArray MA.Seq (MA.Sz1 r) $ \r -> (m MA.!> r)
+-- {-# INLINEABLE asVectorsM #-}
 
 -- The issue here is that the vectors might not all be the same size.  So we give a size and raise and exception (??)
 -- if we're wrong

--- a/src/Data/Algorithm/TSNE/Utils.hs
+++ b/src/Data/Algorithm/TSNE/Utils.hs
@@ -89,13 +89,12 @@ symmetrizeSqM m = MA.computeAs MA.U $ MA.zipWith f m (MA.transpose m) where
     where a = (x + y) / (2 * realToFrac r)
 {-# INLINEABLE symmetrizeSqM #-}
 
-recenterM :: MA.Source r MA.Ix2 Double => MA.Matrix r Double -> MA.Matrix MA.D Double
-recenterM m = MA.zipWith (-) m meansM
+recenterM :: MA.Manifest r MA.Ix2 Double => MA.Matrix r Double -> MA.Matrix MA.D Double
+recenterM m = MA.imap (\(i MA.:. _) e -> e - (meansV MA.! i)) m
     where
 --      meansM = MA.makeArray MA.Seq (MA.Sz2 r c) (\ix -> let (r MA.:. c) = ix in meansV MA.! r)
 --      meansV :: MA.Vector MA.U Double
-      meansM = MA.expandInner (MA.Sz1 c) (\a _ -> a) meansV
-      meansV = MA.computeAs MA.U $ MA.map (/realToFrac c) $ MA.foldlInner (+) 0 m -- fold over columns
+      meansV = MA.computeAs MA.U $ MA.map (/ fromIntegral c) $ MA.foldlInner (+) 0 m -- fold over columns
       MA.Sz2 r c = MA.size m
 {-# INLINEABLE recenterM #-}
 

--- a/src/Data/Algorithm/TSNE/Utils.hs
+++ b/src/Data/Algorithm/TSNE/Utils.hs
@@ -94,6 +94,7 @@ recenterM m = MA.imap (\(i MA.:. _) e -> e - (meansV MA.! i)) m
     where
 --      meansM = MA.makeArray MA.Seq (MA.Sz2 r c) (\ix -> let (r MA.:. c) = ix in meansV MA.! r)
 --      meansV :: MA.Vector MA.U Double
+      --meansV = MA.computeAs MA.U $ MA.map (/ fromIntegral c) $ MA.foldlInner (+) 0 m -- fold over columns
       meansV = MA.computeAs MA.U $ MA.map (/ fromIntegral c) $ MA.foldlInner (+) 0 m -- fold over columns
       MA.Sz2 r c = MA.size m
 {-# INLINEABLE recenterM #-}
@@ -102,10 +103,9 @@ recenterM m = MA.imap (\(i MA.:. _) e -> e - (meansV MA.! i)) m
 -- (i, j) element is distance between ith and jth row
 qdistM :: MA.Matrix MA.U Double -> MA.Matrix MA.U Double
 qdistM ss =
-  let ssTr = MA.transpose ss -- now is
-      MA.Sz2 r c = MA.size ssTr
+  let MA.Sz2 c r = MA.size ss
       dist (i MA.:. j) =
-        let s = distanceSquaredM (ssTr MA.!> i) (ssTr MA.!> j)
+        let s = distanceSquaredM (ss MA.<! i) (ss MA.<! j)
         in 1 / (1 + s)
   in MA.computeAs MA.U $ symmetric (MA.Sz1 r) dist
 {-# INLINEABLE qdistM #-}

--- a/src/Data/Algorithm/TSNE/Utils.hs
+++ b/src/Data/Algorithm/TSNE/Utils.hs
@@ -18,24 +18,24 @@ import Data.Proxy (Proxy(..))
 
 infinity :: Double
 infinity = read "Infinity"
- 
+
 distanceSquared :: [Double] -> [Double] -> Double
 distanceSquared as bs = foldr d 0 (zip as bs)
     where d (a,b) t  = t + (a-b) * (a-b)
 
 symmetrize :: [[Double]] -> [[Double]]
 symmetrize m = (zipWith.zipWith) f m (transpose m)
-    where 
+    where
         f :: Double -> Double -> Double
         f x y = max a 1e-100
-            where a = (x + y) / (2 * (realToFrac.length) m) 
+            where a = (x + y) / (2 * (realToFrac.length) m)
 
 recenter :: [[Double]] -> [[Double]]
 recenter ss = map r ss
-    where 
+    where
         r s = subtract (mean s) <$> s
         mean s = sum s / (realToFrac.length) s
-         
+
 qdist :: [[Double]] -> [[Double]]
 qdist ss = symmetricalMatrixFromTopRight $ qd (transpose ss)
     where
@@ -46,17 +46,17 @@ qdist ss = symmetricalMatrixFromTopRight $ qd (transpose ss)
         q as bs = 1 / (1 + s)
             where
                 s = sum $ zipWith f as bs
-                f a b = (a-b) * (a-b) 
+                f a b = (a-b) * (a-b)
 
 qdist' :: [[Double]] -> [[Double]]
 qdist' ss = (map.map) f qd
     where
         qd = qdist ss
-        f :: Double -> Double 
+        f :: Double -> Double
         f q = max (q / sumsum qd) 1e-100
- 
+
 sumsum :: [[Double]] -> Double
-sumsum m = sum $ sum <$> m 
+sumsum m = sum $ sum <$> m
 
 reprep :: a -> [[a]]
 reprep = repeat.repeat
@@ -83,14 +83,14 @@ symmetrizeSqM :: (MA.Numeric r Double
                  , MA.Source r MA.Ix2 Double)
               => MA.Matrix r Double -> MA.Matrix MA.U Double
 symmetrizeSqM m = MA.computeAs MA.U $ MA.zipWith f m (MA.transpose m) where
-  MA.Sz2 r _ = MA.size m 
+  MA.Sz2 r _ = MA.size m
   f :: Double -> Double -> Double
   f x y = max a 1e-100
-    where a = (x + y) / (2 * realToFrac r) 
+    where a = (x + y) / (2 * realToFrac r)
 {-# INLINEABLE symmetrizeSqM #-}
 
 recenterM :: MA.Source r MA.Ix2 Double => MA.Matrix r Double -> MA.Matrix MA.D Double
-recenterM m = MA.zipWith (-) m meansM 
+recenterM m = MA.zipWith (-) m meansM
     where
 --      meansM = MA.makeArray MA.Seq (MA.Sz2 r c) (\ix -> let (r MA.:. c) = ix in meansV MA.! r)
 --      meansV :: MA.Vector MA.U Double
@@ -103,33 +103,37 @@ recenterM m = MA.zipWith (-) m meansM
 -- (i, j) element is distance between ith and jth row
 qdistM :: MA.Matrix MA.U Double -> MA.Matrix MA.U Double
 qdistM ss =
-  let ssTr = MA.transpose ss -- now is points x dimension 
+  let ssTr = MA.transpose ss -- now is
       MA.Sz2 r c = MA.size ssTr
-      eDist a b = let x = (a - b) in x * x
-      dist ix =
-        let (i MA.:. j) = ix 
-            s = MA.sum $ MA.zipWith eDist (ssTr MA.!> i) (ssTr MA.!> j)
+      eDist a b = (a - b)^^2
+      dist (i MA.:. j) =
+        let s = MA.sum $ MA.zipWith eDist (ssTr MA.!> i) (ssTr MA.!> j)
         in 1 / (1 + s)
-      {-# SCC dist #-}  
-      upperTri = MA.computeAs MA.U $ MA.upperTriangular MA.Par (MA.Sz1 r) dist
-      {-# SCC upperTri "blah" #-}
-  in MA.makeArray MA.Par (MA.Sz2 r r) $ \(i MA.:. j) ->
-    case compare i j of
-      EQ -> 0
-      LT -> upperTri MA.! (i MA.:. j)
-      GT -> upperTri MA.! (j MA.:. i)
-{-# INLINEABLE qdistM #-}                
+  in MA.computeAs MA.U $ symmetric (MA.Sz1 r) dist
+{-# INLINEABLE qdistM #-}
 
-qdistM'' ::  MA.Matrix MA.U Double ->  MA.Matrix MA.D Double
-qdistM'' qd =
-  let sumQD = MA.sum qd
-      f q = max (q / sumQD) 1e-100        
-  in MA.map f qd
-{-# INLINE qdistM'' #-}
+symmetric :: Num e => MA.Sz1 -> (MA.Ix2 -> e) -> MA.Matrix MA.DL e
+symmetric (MA.Sz1 n) f =
+  let sz = MA.Sz2 n n
+   in MA.makeLoadArray MA.Seq sz 0 $ \_scheduler wr ->
+        MA.forM_ (0 MA...: n) $ \i ->
+          MA.forM_ ((i + 1) MA...: n) $ \j ->
+            let ix = i MA.:. j
+                e = f ix
+             in wr ix e >> wr (j MA.:. i) e
+{-# INLINE symmetric #-}
+
 
 qdistM' :: MA.Matrix MA.U Double -> MA.Matrix MA.D Double
-qdistM' ss = qdistM'' $ qdistM ss
+qdistM' = qdistM'' . qdistM
 {-# INLINEABLE qdistM' #-}
+
+qdistM'' :: MA.Matrix MA.U Double -> MA.Matrix MA.D Double
+qdistM'' qd =
+  let sumQD = MA.sum qd
+      f q = max (q / sumQD) 1e-100
+  in MA.map f qd
+{-# INLINEABLE qdistM'' #-}
 
 zipWith4M :: (MA.Index ix
              , MA.Source r1 ix e1
@@ -155,12 +159,26 @@ asVectorsM m =
 
 -- The issue here is that the vectors might not all be the same size.  So we give a size and raise and exception (??)
 -- if we're wrong
+-- asMatrixM ::
+--   forall e r r'
+--   .(MA.Manifest r MA.Ix1 (MA.Array r' MA.Ix1 e)
+--    , MA.OuterSlice r' MA.Ix1 e
+--    ) => MA.Vector r (MA.Vector r' e) -> MA.Matrix MA.U e
 asMatrixM ::
-  forall e r r'
-  .(MA.Manifest r MA.Ix1 (MA.Array r' MA.Ix1 e)
-   , MA.OuterSlice r' MA.Ix1 e
-   ) => Int -> MA.Vector r (MA.Vector r' e) -> MA.Matrix MA.D e 
-asMatrixM cols vs = MA.expandWithin MA.Dim1 (MA.Sz1 cols) (\v j -> v MA.!> j) vs
+     ( MA.Mutable r1 MA.Ix2 e
+     , MA.Source r2 Int (MA.Array r3 Int e)
+     , MA.Source r3 Int e
+     )
+  => MA.Array r2 MA.Ix1 (MA.Array r3 MA.Ix1 e)
+  -> MA.Array r1 MA.Ix2 e
+asMatrixM vs =
+  MA.createArrayST_ sz $ \marr ->
+    MA.iforM_ vs $ \ i v -> do
+      MA.iforM_ v $ \ j e -> do
+        MA.writeM marr (i MA.:. j) e
+  where v0 = MA.evaluate' vs 0
+        sz = MA.consSz (MA.size vs) (MA.size v0)
+  --MA.expandWithin MA.Dim1 (MA.Sz1 cols) (\v j -> v MA.!> j) vs
 {-# INLINEABLE asMatrixM #-}
 
 fromOuterSlices ::

--- a/src/Data/Algorithm/TSNE/Utils.hs
+++ b/src/Data/Algorithm/TSNE/Utils.hs
@@ -105,9 +105,8 @@ qdistM :: MA.Matrix MA.U Double -> MA.Matrix MA.U Double
 qdistM ss =
   let ssTr = MA.transpose ss -- now is
       MA.Sz2 r c = MA.size ssTr
-      eDist a b = (a - b)^^2
       dist (i MA.:. j) =
-        let s = MA.sum $ MA.zipWith eDist (ssTr MA.!> i) (ssTr MA.!> j)
+        let s = distanceSquaredM (ssTr MA.!> i) (ssTr MA.!> j)
         in 1 / (1 + s)
   in MA.computeAs MA.U $ symmetric (MA.Sz1 r) dist
 {-# INLINEABLE qdistM #-}

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-7.3
+resolver: lts-16.6
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/stack.yaml
+++ b/stack.yaml
@@ -41,6 +41,10 @@ packages:
 # (e.g., acme-missiles-0.3)
 extra-deps:
 - normaldistribution-1.1.0.3
+- github: lehins/massiv
+  commit: 4e9db8dd4862292b898d55985ffc120e835f2aaa
+  subdirs:
+    - massiv
 # - normaldistribution-1.1
 
 # Override default flag values for local packages and extra-deps

--- a/timing/MainM.hs
+++ b/timing/MainM.hs
@@ -36,10 +36,10 @@ main = do
 
     t0 <- getCurrentTime
     inputMatrix <- MA.fromListsM MA.Seq $ take n' inputData
---    forTsne3D_M (outputResult t0) def Nothing $ inputMatrix
+    forTsne3D_M (outputResult t0) def Nothing inputMatrix
 
-    runEffect $ for ((tsne3D_M def Nothing $ inputMatrix) >-> Pipes.take iters) $ \r -> do
-      lift $ outputResult t0 r
+    -- runEffect $ for ((tsne3D_M def Nothing $ inputMatrix) >-> Pipes.take iters) $ \r -> do
+    --   lift $ outputResult t0 r
     
 readDataFile :: FilePath -> IO [[Double]]
 readDataFile f = do

--- a/timing/MainM.hs
+++ b/timing/MainM.hs
@@ -40,21 +40,20 @@ main = do
 
     -- runEffect $ for ((tsne3D_M def Nothing $ inputMatrix) >-> Pipes.take iters) $ \r -> do
     --   lift $ outputResult t0 r
-    
+
 readDataFile :: FilePath -> IO [[Double]]
 readDataFile f = do
     d <- readFile f
     return $ map read (lines d)
 
-outputResult :: UTCTime -> TSNEOutput3D -> IO ()
+outputResult :: UTCTime -> TSNEOutput3D_M -> IO ()
 outputResult t0 s = do
-    let i = tsneIteration3D s
+    let i = tsneIteration3D_M s
 
-    when (i > 0 && (i == 1 || i `mod` 100 == 0)) $ do 
+    when (i > 0 && (i == 1 || i `mod` 100 == 0)) $ do
         putStrLn $ "iteration: " ++ show i
         t <- getCurrentTime
         let dt = diffUTCTime t t0
             ms = round $ 1000.0 * realToFrac dt / realToFrac i
         putStrLn $ "  elapsed time: " ++ show dt
         putStrLn $ "  average iteration time: " ++ show ms ++ "ms"
-

--- a/tsne.cabal
+++ b/tsne.cabal
@@ -74,7 +74,8 @@ executable haskell_tsne_massiv_example
                        massiv,
                        pipes,
                        tsne
-  ghc-options:         -threaded -O2 -with-rtsopts=-N
+  ghc-options:         -threaded -O2
+-- -with-rtsopts=-N
   default-language:    Haskell2010
   
   

--- a/tsne.cabal
+++ b/tsne.cabal
@@ -15,13 +15,13 @@ cabal-version:       >=1.10
 library
   hs-source-dirs:      src
   exposed-modules:     Data.Algorithm.TSNE,
-                       Data.Algorithm.TSNE.Types, 
+                       Data.Algorithm.TSNE.Types,
                        Data.Algorithm.TSNE.Utils,
-                       Data.Algorithm.TSNE.Checks, 
-                       Data.Algorithm.TSNE.Preparation, 
-                       Data.Algorithm.TSNE.Stepping, 
-                       Data.Algorithm.TSNE.Run2D, 
-                       Data.Algorithm.TSNE.Run3D 
+                       Data.Algorithm.TSNE.Checks,
+                       Data.Algorithm.TSNE.Preparation,
+                       Data.Algorithm.TSNE.Stepping,
+                       Data.Algorithm.TSNE.Run2D,
+                       Data.Algorithm.TSNE.Run3D
   build-depends:       base >= 4.7 && < 5,
                        data-default,
                        deepseq,
@@ -77,8 +77,8 @@ executable haskell_tsne_massiv_example
   ghc-options:         -threaded -O2
 -- -with-rtsopts=-N
   default-language:    Haskell2010
-  
-  
+
+
 executable haskell_tsne_timing
   hs-source-dirs:      timing
   main-is:             Main.hs
@@ -87,7 +87,8 @@ executable haskell_tsne_timing
                        pipes,
                        time,
                        tsne
-  ghc-options:         -threaded -O2 -with-rtsopts=-N
+  ghc-options:         -threaded -O2
+ -- -with-rtsopts=-N
   default-language:    Haskell2010
 
 executable haskell_tsne_massiv_timing
@@ -99,8 +100,9 @@ executable haskell_tsne_massiv_timing
                        pipes,
                        time,
                        tsne
-  ghc-options:         -threaded -O2 -with-rtsopts=-N
-  default-language:    Haskell2010  
+  ghc-options:         -threaded -O2
+   ---with-rtsopts=-N
+  default-language:    Haskell2010
 
 source-repository head
   type:     mercurial


### PR DESCRIPTION
@adamConnerSax Here is a collection of optimizations that I was able to identify

It uses the yet unreleased version of massiv, but that is not required, nor will be a problem, since I can make a release any time.

It is still 5 to 6 times slower when compared to the original implementation with lists, which is really surprising, but I do have a very plausible explanation for it. I'll elaborate more on gitter.

Current PR does not use any parallelization, it is always better to leave this optimization to the end, once sequential code is performant.